### PR TITLE
extractFromJS.js now supports Windows and UNIX systems

### DIFF
--- a/javascript/extractFromJS.js
+++ b/javascript/extractFromJS.js
@@ -120,7 +120,7 @@ The <what> argument must be one of:
         if (fileListFile === "all") {
             jsFiles = relativeJsFiles.map(f => dir + (dir.endsWith("/") ? "" : "/") + f);
         } else {
-            const filesToConsider = new Set(fs.readFileSync(fileListFile, {encoding:"utf8"}).split("\n"));
+            const filesToConsider = new Set(fs.readFileSync(fileListFile, {encoding:"utf8"}).split(/\r?\n/));
             jsFiles = relativeJsFiles.map(f => dir + (dir.endsWith("/") ? "" : "/") + f).filter(p => filesToConsider.has(p));
         }
         console.log("Total number of files: " + jsFiles.length);


### PR DESCRIPTION
Fix for bug reported in [Issue 7](https://github.com/michaelpradel/DeepBugs/issues/7). On Windows, users would previously see:
```
Total number of files: 0
Left in worklist: 0. Spawning an instance.
Left in worklist: 0. Spawning an instance.
Left in worklist: 0. Spawning an instance.
Left in worklist: 0. Spawning an instance.
```

The call to `.split` in `extractFromJS.js` now handles `\r` and `\n` for Windows and UNIX support.