### PR TITLE
Fix LearningDataIncorrectBinaryOperand

### DIFF
--- a/python/LearningDataIncorrectBinaryOperand.py
+++ b/python/LearningDataIncorrectBinaryOperand.py
@@ -116,6 +116,9 @@ class LearningData(object):
                 tries_left -= 1
 
             if not found:
+                xs.pop()
+                ys.pop()
+                code_pieces.pop()
                 return
 
             other_operand_vector = name_to_vector[other_operand.op]


### PR DESCRIPTION
Pull request #19 has introduced a bug in LearningDataIncorrectBinaryOperand.py.
Originally, this learning data generator either always generated a negative and a positive example, or none at all, if no suitable replacement operand was found. The mentioned PR made it is possible, that for a given binary operation, only the positive example is generated. This violates the assumption in [`BugLearnAndValidate.py`](https://github.com/michaelpradel/DeepBugs/blob/574429468a8184bfe502e8776e7ddcda11a9b6e0/python/BugLearnAndValidate.py#L166), that there must always be alternating pairs of correct and incorrect examples.
This causes `BugLearnAndValidate.py` to either crash, if the number of generated validation examples is odd, or that it produces erroneous validation metrics.

This fix simply removes the generated positive example, if no negative example can be generated.
Thus, the code should behave the same way it did before the mentioned PR.

Best regards
Florian